### PR TITLE
Default symlink to chef should be in /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install the `chef` script as follows:
 $ git  clone  https://github.com/cpb-/chef
 $ cd  chef/
 $ pip3  install  -r requirements.txt
-$ ln  -sf  $(realpath  chef)  ~/bin
+$ sudo  ln  -sf  $(realpath  chef)  /usr/local/bin
 ```
 
 Ensure the `~/bin` directory is in your `PATH` environment variable.


### PR DESCRIPTION
According to this doc --> http://www.pathname.com/fhs/pub/fhs-2.3.pdf
It would be more appropriate to create a symbolic link in /usr/local/bin than in $HOME/bin.

Not everyone has a bin dir in its home directory, do you agree with that ?