### PR TITLE
[DEV] Error message when called without sub-command.

### DIFF
--- a/chef/chef.py
+++ b/chef/chef.py
@@ -537,7 +537,8 @@ class ChefCall:
         parser.add_argument('-v', '--verbose', action='store_true', help='activate verbose printing (of called subcommands)')
 
         # parsing subcommand's arguments
-        subparsers = parser.add_subparsers(help='subcommands of Chef')
+        subparsers = parser.add_subparsers(help='subcommands of Chef', dest='sub-command')
+        subparsers.required = True
 
         # `cook` command (`init` + `update` + `generate`)
         cook_parser = subparsers.add_parser('cook', help='prepare the directories and cook the menu')

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,7 @@ macro(test path)
                     ${CMAKE_CURRENT_SOURCE_DIR}/${path})
 endmacro()
 
+test(basic/no-subcommand)
 test(basic/build)
 test(basic/clean)
 test(basic/generate)

--- a/test/basic/no-subcommand/test
+++ b/test/basic/no-subcommand/test
@@ -1,0 +1,9 @@
+# `chef` command with no argument must fail with an error message.
+rm -f error.txt
+expect_fail chef > error.txt 2>&1
+linesInFile error.txt 3
+rm -f error.txt
+
+exit 0
+
+


### PR DESCRIPTION
Previous versions of `chef` quit silently when called without sub-command:

```
[~]$ chef
[~]$
```

With this patch an error message is displayed.

```
[~]$ chef
usage: Chef [-h] [--debug] [-v]
            {cook,init,update,generate,show,build,clean} ...
Chef: error: the following arguments are required: sub-command
[~]$
```