### PR TITLE
[FIX] Exit status without argument.

### DIFF
--- a/chef/chef.py
+++ b/chef/chef.py
@@ -662,6 +662,7 @@ class ChefCall:
             self.clargs.func() # call function of selected command
         else:
             parser.print_usage()
+            sys.exit(1)
 
         sys.exit(0)
 

--- a/test/basic/no-subcommand/test
+++ b/test/basic/no-subcommand/test
@@ -1,7 +1,7 @@
 # `chef` command with no argument must fail with an error message.
 rm -f error.txt
 expect_fail chef > error.txt 2>&1
-linesInFile error.txt 3
+linesInFile error.txt 2
 rm -f error.txt
 
 exit 0


### PR DESCRIPTION
Without argument the `chef` command has to fail with a non-zero exit status.