### PR TITLE
json schema ressource must be decoded prior to being loaded as json

### DIFF
--- a/chef/chef.py
+++ b/chef/chef.py
@@ -686,7 +686,7 @@ class ChefCall:
             except Exception as e:
                 fatal_error('menu load error:', e)
 
-            schema = json.loads(pkg_resources.resource_string(__name__, "chef-menu-schema.json"))
+            schema = json.loads(pkg_resources.resource_string(__name__, "chef-menu-schema.json").decode('utf-8'))
             try:
                 jsonschema.validate(self.menu, schema)
             except Exception as e:


### PR DESCRIPTION
Hello Christophe, Pat,

Using the brand new 1.0.0 chef version, I had some difficulties to use this tools having the following error:

```
$ chef -v
Traceback (most recent call last):
  File "/usr/local/bin/chef", line 33, in <module>
    sys.exit(load_entry_point('chef', 'console_scripts', 'chef')())
  File "/usr/local/lib/python3.5/dist-packages/chef/chef.py", line 790, in main
    ChefCall()
  File "/usr/local/lib/python3.5/dist-packages/chef/chef.py", line 689, in __init__
    schema = json.loads(pkg_resources.resource_string(__name__, "chef-menu-schema.json"))
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

and some documentation links to confirm the modification
--> https://setuptools.readthedocs.io/en/latest/pkg_resources.html
--> https://docs.python.org/fr/3.6/library/json.html#json.loads

I am suprised you didn't encounter this error ? My current python version is 3.5.2, ubuntu 16.04 LTS.

Regards,
Adrien M.

