### PR TITLE
Chef installation doc procedure updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@ Install `chef` from source:
 ```
 $ git clone https://github.com/cpb-/chef
 $ cd chef/
-$ python3 setup.py install
+$ sudo pip3 install .
+```
+
+### Installing chef to contribute
+
+To ease software modifications of chef itself, use the `-e` option with pip3 to
+install chef with editable mode enabled.
+This way you can bring your modifications to `chef.py` and call your updated `chef`
+tool anywhere you want to run it.
+```
+sudo pip3 install -e .
 ```
 
 ## `chef` command line arguments
@@ -356,5 +366,5 @@ For example, `chef --dry-run cook <menu-filename>` will display all the shell
 commands that `chef` would execute. The output could even be redirected into a
 file that may later be run as a shell script.
 
-The `--dry-run` output also displays the content of the files produced by 
+The `--dry-run` output also displays the content of the files produced by
 `chef`.


### PR DESCRIPTION
Hello Christophe,

When using the released 1.0.0 chef version, I followed the README to install the tool and ran into some difficulties:
https://github.com/cpb-/chef/blob/master/README.md#installing-chef

With precious help from @Stimaleger  and @pboettch , it is recommended to:

- not use the line `python3 setup.py install`, use pip3 tool instead
- use a different installation if you are a developer or a simple user

On my computer (Ubuntu 16.04 / Python 3.5.2), the current installation procedure with setup.py method doesn't work. Chef installation works apparently well but then, using chef raise the following error:

```
$ chef 
Traceback (most recent call last):
  File "/usr/local/bin/chef", line 33, in <module>
    sys.exit(load_entry_point('chef==1.0.0', 'console_scripts', 'chef')())
  File "/usr/local/bin/chef", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/home/installer/.local/lib/python3.5/site-packages/importlib_metadata/__init__.py", line 95, in load
    module = import_module(match.group('module'))
  File "/usr/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'chef'
```