### PR TITLE
--immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,22 @@ followed by options, menu filename or build-config-names.
 
 The top-level sub-command proposed by `cooker` is:
 
-- `cooker cook <menu-file> [<build-configs>...]`: does the whole production job from the
+- `cooker cook <menu-file> [<build-configs>...] [--immutable]`: does the whole production job from the
   initial configuration and downloading up to the final image(s).
+
+  For `--immutable` see `cooker init --immutable`.
 
 In fact, `cooker cook` is equivalent to a collection of low-level commands:
 
-- `cooker init <menu-file>`: store the current menu filename into the
+- `cooker init <menu-file> [--immutable]`: store the current menu filename into the
   `.cookerconfig` configuration file. The content of the configuration will be
   explained later.
+  In immutable initialisation a copy of the provided menu files is stored and the copies filename referenced in the
+  configuration instead of the original files.
+  This allows a sense of immutability across consecutive cooker calls.
+
+  In order to wipe this immutable configuration simply `cooker init` again.
+
 
 - `cooker update`: fetch and checkout the version of each layer indicated in the
   current menu file.

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -7,9 +7,12 @@ import json
 import os
 import re
 import shlex
+import shutil
 import sys
 from collections.abc import Iterable, Mapping
+from hashlib import file_digest
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from urllib.parse import urlparse
 
 import jsonschema
@@ -55,6 +58,7 @@ def merge_dicts(base, other):
 
 
 class Config:
+    DEFAULT_MENU_CACHE_DIR = ".cookercache/"
     DEFAULT_CONFIG_FILENAME = ".cookerconfig"
     DEFAULT_CONFIG = {
         "menu": "",
@@ -142,6 +146,61 @@ class Config:
     def project_root(self):
         return os.path.dirname(self.filename)
 
+    def wipe_unreferenced_cooker_cache(self):
+        """Drop immutable menu copies if they exist.
+
+        Drop .cookercache/ if it's empty afterwards.
+        """
+        if self.menu_cache_dir.exists() and self.menu_cache_dir.is_dir():
+            cached_files = [f for f in self.menu_cache_dir.iterdir() if f.is_file()]
+            serialized = str(self.cfg)
+            for cf in cached_files:
+                if cf.name not in serialized:
+                    cf.unlink(missing_ok=True)
+            # get rid of the cache directory if it is empty
+            if not any(self.menu_cache_dir.iterdir()):
+                shutil.rmtree(self.menu_cache_dir)
+
+    def create_immutable_copy(self, menu_file: Path) -> Path:
+        """Create an immutable copy of a menu file
+
+        to prevent changes or removal of the original file affecting following build
+        steps.
+
+        Raise a FileNotFoundError in case the menu_file does not exist.
+
+        Return the path of the copied file.
+        """
+        if not menu_file.exists():
+            msg = f"menu file '{menu_file}' does not exist"
+            raise FileNotFoundError(msg)
+
+        # create cache directory if it does not exist
+        self.menu_cache_dir.mkdir(exist_ok=True)
+
+        intermediate: Path
+
+        with NamedTemporaryFile(mode="wb") as temp_file_handle:
+            if menu_file.is_fifo():
+                # file is a pseudo file and can only be read once
+                with menu_file.open("rb") as menu_handle:
+                    shutil.copyfileobj(menu_handle, temp_file_handle)
+                # to avoid the necessity of reopening the temporary file
+                # jump to position 0 in it again
+                temp_file_handle.seek(0)
+                intermediate = Path(temp_file_handle.name).absolute()
+            else:
+                intermediate = menu_file
+
+            # filename = hash file
+            with intermediate.open("rb") as handle:
+                target_filename = file_digest(handle, "sha256").hexdigest()
+            target_path = self.menu_cache_dir / target_filename
+
+            # copy file to cachedir/filename
+            shutil.copy(intermediate, target_path)
+        return target_path
+
     def _interpret_path_str(self, path_string: str) -> str:
         """Interpret the provided string as absolute or relative path
 
@@ -154,15 +213,27 @@ class Config:
             return os.path.realpath(path_string)
         return os.path.relpath(path_string, self.path)
 
-    def set_menu(self, menu_file):
-        self.cfg["menu"] = self._interpret_path_str(menu_file)
+    def set_menu(self, menu_file, *, mutable=True):
+        interpreted_path_str = self._interpret_path_str(menu_file)
+        self.cfg["menu"] = (
+            interpreted_path_str
+            if mutable
+            else str(self.create_immutable_copy(Path(interpreted_path_str)))
+        )
 
-    def set_additional_menus(self, additional_menus: Iterable[Path]):
+    def set_additional_menus(self, additional_menus: Iterable[Path], *, mutable=True):
         self.cfg["additional_menus"] = list()
         for menu_file in additional_menus:
+            interpreted_path_str = self._interpret_path_str(str(menu_file))
             self.cfg["additional_menus"].append(
-                self._interpret_path_str(str(menu_file))
+                interpreted_path_str
+                if mutable
+                else str(self.create_immutable_copy(Path(interpreted_path_str)))
             )
+
+    @property
+    def menu_cache_dir(self) -> Path:
+        return Path(self.project_root()) / self.DEFAULT_MENU_CACHE_DIR
 
     def set_layer_dir(self, path):
         # paths in the config-file are relative to the project-dir
@@ -387,10 +458,14 @@ class CookerCommands:
         dl_dir=None,
         sstate_dir=None,
         additional_menus: list[Path] | None = None,
+        *,
+        immutable=None,
     ):
         """cooker-command 'init': (re)set the configuration file"""
-        self.config.set_menu(menu_name)
-        self.config.set_additional_menus(additional_menus)
+        mutable = not immutable
+        self.config.set_menu(menu_name, mutable=mutable)
+        self.config.set_additional_menus(additional_menus, mutable=mutable)
+        self.config.wipe_unreferenced_cooker_cache()
 
         if layer_dir:
             self.config.set_layer_dir(layer_dir)
@@ -1129,6 +1204,12 @@ class CookerCall:
             help="download all sources needed for offline-build",
         )
         cook_parser.add_argument(
+            "-i",
+            "--immutable",
+            action="store_true",
+            help="work on immutable copies of the provided menu files",
+        )
+        cook_parser.add_argument(
             "-k",
             "--keepgoing",
             action="store_true",
@@ -1165,6 +1246,12 @@ class CookerCall:
             help="re-init an existing project",
             default=False,
             action="store_true",
+        )
+        init_parser.add_argument(
+            "-i",
+            "--immutable",
+            action="store_true",
+            help="work on immutable copies of the provided menu files",
         )
         init_parser.add_argument(
             "-l", "--layer-dir", help="path where layers will saved/cloned"
@@ -1467,6 +1554,7 @@ class CookerCall:
             self.clargs.dl_dir,
             self.clargs.sstate_dir,
             additional_menus=self.additional_menus,
+            immutable=self.clargs.immutable,
         )
 
     def update(self):
@@ -1493,7 +1581,9 @@ class CookerCall:
 
     def cook(self):
         self.commands.init(
-            str(self.clargs.menu[0]), additional_menus=self.additional_menus
+            str(self.clargs.menu[0]),
+            additional_menus=self.additional_menus,
+            immutable=self.clargs.immutable,
         )
         self.commands.update()
         self.commands.generate()

--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -1453,13 +1453,15 @@ class CookerCall:
         if (
             "menu" in self.clargs and self.clargs.menu is not None
         ):  # menu-file from the cmdline has priority
-            menu_file = self.clargs.menu[0]
+            menu_file = self._copy_to_cache_if_pseudofile(self.clargs.menu[0])
             if (
                 "additional_menus" in self.clargs
                 and self.clargs.additional_menus is not None
             ):
                 for additional_menu in self.clargs.additional_menus:
-                    additional_menus.append(additional_menu[0])
+                    additional_menus.append(
+                        self._copy_to_cache_if_pseudofile(additional_menu[0])
+                    )
         elif not self.config.empty():  # or the one from the config-file
             try:
                 menu_file = Path(self.config.menu())
@@ -1540,6 +1542,15 @@ class CookerCall:
 
         sys.exit(0)
 
+    def _copy_to_cache_if_pseudofile(self, potential_pseudo_file: Path):
+        """Transparently return a regular file.
+
+        In case the provided file is a pseudo file, cache a copy and return its path.
+        """
+        if potential_pseudo_file.is_fifo():
+            return self.config.create_immutable_copy(potential_pseudo_file)
+        return potential_pseudo_file
+
     def init(self):
         """function use by command-line-arg-parser as entry point for the 'init'"""
         if not self.clargs.force and not self.config.empty():
@@ -1548,7 +1559,7 @@ class CookerCall:
             )
 
         self.commands.init(
-            str(self.clargs.menu[0]),
+            str(self._copy_to_cache_if_pseudofile(self.clargs.menu[0])),
             self.clargs.layer_dir,
             self.clargs.build_dir,
             self.clargs.dl_dir,

--- a/test/basic/pseudo-files/test
+++ b/test/basic/pseudo-files/test
@@ -7,9 +7,9 @@ cat debug | awk '/---end-menu-dump---/{exit} f; /---start-menu-dump---/{f=1}' > 
 # the pseudo file menus contents are read, so kirkstone-next is checked out instead of the kirkstone branch
 diff menu-dump.json $S/menu-dump.json.ref
 
-# cooker cook then produces a .cookerconfig containing a reference to a no longer existing file
-grep --regexp="/proc/.*/fd/pipe\:\[.*\]" .cookerconfig
-expect_fail stat $(grep --regexp="/proc/.*/fd/pipe\:\[.*\]" cookerconfig-dump.json.ref )
+# cooker cook then produces a .cookerconfig containing a reference in .cookercache/ to avoid a no longer existing file
+# because of that there are no invalid references to /proc/*/fd/pipe/* in cookerconfig
+expect_fail grep --regexp="/proc/.*/fd/pipe\:\[.*\]" .cookerconfig
 
-# as subsequent cooker calls try to read .cookerconfig and the referenced files, they fail
-expect_fail cooker --dry-run update
+# as subsequent cooker calls try to read .cookerconfig and the referenced files, they do not fail due to the cache
+cooker --dry-run update


### PR DESCRIPTION
This is not meant to be merged yet, but to open a room for discussion about implementation.

The two refactorings have been extracted into #166 and can be reviewed there.
I'll rebase this.

This is currently a poc, which does appear to be working.

It has problems I need to take care of, which I only saw after implementing it:

- [x] proper pseudofile handling
- [x] **blocked by #172**
- [x] ~~**blocked by #170**~~
- [x] ~~**blocked by #168**~~
- [x] ~~**blocked by #166**~~
- [x] ~~this project currently aims for python 3.10 compatibility. `hashlib.file_digest()` was introduced in 3.11.~~ implemented a hash function, which can be cleanly dropped upon updating the minimal python
- ~I used pathlib, which I do think is a good idea in general, but won't do it here due to the `--dry-run` feature which is based on overriding `os.path`.~
- ~same goes for shutil.rmtree~


In a few iterations this might resolve #165 