### PR TITLE
Fix checkout failure when switching to a branch not yet known locally

### DIFF
--- a/cooker/cooker.py
+++ b/cooker/cooker.py
@@ -507,6 +507,8 @@ class CookerCommands:
                 + " be reproducible!"
             )
             info(f"Updating source {local_dir}... ")
+            if has_remote:
+                CookerCommands._run_git_command(["git", "fetch", "--all"], local_dir)            
             CookerCommands._run_git_command(["git", "checkout", branch], local_dir)
             if has_remote:
                 CookerCommands._run_git_command(["git", "pull"], local_dir)


### PR DESCRIPTION
when running cooker update on a layer where a branch has been created after the initial clone, cooker is not able to fetch this new branch